### PR TITLE
Fix lint errors and improve typings

### DIFF
--- a/src/components/DevTools/AdvancedObfuscation.tsx
+++ b/src/components/DevTools/AdvancedObfuscation.tsx
@@ -1,16 +1,19 @@
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { MonacoEditor } from '../Editor/MonacoEditor';
-import { Shield, Download, Copy, FileText, Settings, Palette } from 'lucide-react';
+import { Download, Copy, FileText, Palette } from 'lucide-react';
 import { useToast } from "@/hooks/use-toast";
 import useEditorStore from '@/stores/useEditorStore';
 
-// Import dynamique pour JavaScript Obfuscator
-let JavaScriptObfuscator: any = null;
-let htmlMinifier: any = null;
-let CleanCSS: any = null;
+// Dynamic imports for heavy libraries
+type JavaScriptObfuscatorModule = typeof import('javascript-obfuscator');
+interface HtmlMinifierModule {
+  minify: (input: string, options?: Record<string, unknown>) => string;
+}
+
+let JavaScriptObfuscator: JavaScriptObfuscatorModule | null = null;
+let htmlMinifier: HtmlMinifierModule | null = null;
 
 if (typeof window !== 'undefined') {
   import('javascript-obfuscator').then(module => {
@@ -28,7 +31,6 @@ export function AdvancedObfuscation() {
   const { toast } = useToast();
   const { originalCode, currentLanguage } = useEditorStore();
   
-  const [activeTab, setActiveTab] = useState('js');
   const [obfuscatedContent, setObfuscatedContent] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
   const [stats, setStats] = useState<{
@@ -139,6 +141,7 @@ export function AdvancedObfuscation() {
         duration: 2000,
       });
     } catch (error) {
+      console.error(error);
       toast({
         title: "Erreur",
         description: "Impossible de copier le code",

--- a/src/components/DevTools/ComplexityPanel.tsx
+++ b/src/components/DevTools/ComplexityPanel.tsx
@@ -5,8 +5,6 @@ import { Activity, TrendingUp, AlertCircle, CheckCircle } from 'lucide-react';
 import useEditorStore from '@/stores/useEditorStore';
 
 // Import dynamique avec fallback pour compatibilité navigateur
-let escomplex: any = null;
-let isComplexityAvailable = false;
 
 // Fallback pour escomplex qui ne marche pas en navigateur
 const performSimpleComplexityAnalysis = (code: string) => {
@@ -84,7 +82,8 @@ interface ComplexityResult {
 export function ComplexityPanel() {
   const originalCode = useEditorStore(state => state.originalCode);
   const currentLanguage = useEditorStore(state => state.currentLanguage);
-  const [complexityResults, setComplexityResults] = React.useState(null);
+  const [complexityResults, setComplexityResults] =
+    React.useState<ComplexityResult | null>(null);
 
   useEffect(() => {
     // Seulement analyser le code JavaScript/TypeScript

--- a/src/components/DevTools/DevConsole.tsx
+++ b/src/components/DevTools/DevConsole.tsx
@@ -29,6 +29,18 @@ interface DevConsoleProps {
   onToggle: () => void;
 }
 
+interface DevConsoleAPI {
+  addMessage: (
+    level: ConsoleMessage['level'],
+    source: string,
+    message: string
+  ) => void;
+}
+
+interface DevConsoleWindow extends Window {
+  devConsole?: DevConsoleAPI;
+}
+
 export function DevConsole({ isOpen, onToggle }: DevConsoleProps) {
   const [messages, setMessages] = useState<ConsoleMessage[]>([]);
   const [isMinimized, setIsMinimized] = useState(false);
@@ -71,10 +83,10 @@ export function DevConsole({ isOpen, onToggle }: DevConsoleProps) {
 
   // Exposer la fonction globalement pour les autres composants
   useEffect(() => {
-    (window as any).devConsole = { addMessage };
-    
+    (window as DevConsoleWindow).devConsole = { addMessage };
+
     return () => {
-      delete (window as any).devConsole;
+      delete (window as DevConsoleWindow).devConsole;
     };
   }, []);
 
@@ -231,8 +243,9 @@ export function DevConsole({ isOpen, onToggle }: DevConsoleProps) {
 // Hook pour utiliser la console de développement
 export function useDevConsole() {
   const addMessage = (level: ConsoleMessage['level'], source: string, message: string) => {
-    if ((window as any).devConsole) {
-      (window as any).devConsole.addMessage(level, source, message);
+    const win = window as DevConsoleWindow;
+    if (win.devConsole) {
+      win.devConsole.addMessage(level, source, message);
     }
   };
 

--- a/src/components/DevTools/ObfuscationPanel.tsx
+++ b/src/components/DevTools/ObfuscationPanel.tsx
@@ -9,7 +9,8 @@ import { Label } from "@/components/ui/label";
 import useEditorStore from '@/stores/useEditorStore';
 
 // Import dynamique pour éviter les erreurs SSR
-let JavaScriptObfuscator: any = null;
+type JavaScriptObfuscatorModule = typeof import('javascript-obfuscator');
+let JavaScriptObfuscator: JavaScriptObfuscatorModule | null = null;
 
 if (typeof window !== 'undefined') {
   import('javascript-obfuscator').then(module => {

--- a/src/components/Editor/EditorPane.tsx
+++ b/src/components/Editor/EditorPane.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import type * as Monaco from 'monaco-editor';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -17,8 +18,11 @@ import useFileStore from '@/stores/useFileStore';
 // Déclaration des types pour Monaco
 declare global {
   interface Window {
-    monaco: any;
-    require: any;
+    monaco: typeof import('monaco-editor');
+    require: {
+      config: (options: Record<string, unknown>) => void;
+      (modules: string[], callback: () => void): void;
+    };
   }
 }
 
@@ -27,7 +31,7 @@ type EditorPaneProps = {
 };
 
 const EditorPane = ({ type }: EditorPaneProps) => {
-  const editorRef = useRef<any>(null);
+  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isMaximized, setIsMaximized] = React.useState<boolean>(false);
   const [isMinimized, setIsMinimized] = React.useState<boolean>(false);
@@ -49,7 +53,7 @@ const EditorPane = ({ type }: EditorPaneProps) => {
 
   // Initialize Monaco Editor
   useEffect(() => {
-    let monacoInstance: any = null;
+    let monacoInstance: typeof Monaco | null = null;
     let script: HTMLScriptElement | null = null;
 
     const initMonaco = async () => {

--- a/src/components/Editor/MonacoEditor.tsx
+++ b/src/components/Editor/MonacoEditor.tsx
@@ -81,7 +81,10 @@ export function MonacoEditor({
 // Global type declaration for Monaco
 declare global {
   interface Window {
-    monaco: any;
-    require: any;
+    monaco: typeof import('monaco-editor');
+    require: {
+      config: (options: Record<string, unknown>) => void;
+      (modules: string[], callback: () => void): void;
+    };
   }
 }

--- a/src/components/Preview/PreviewPane.tsx
+++ b/src/components/Preview/PreviewPane.tsx
@@ -61,8 +61,9 @@ const PreviewPane = () => {
           doc.close();
           setPreviewError(null);
         }
-      } catch (error: any) {
-        setPreviewError(error.message);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setPreviewError(message);
       }
     }
   };

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -105,8 +105,11 @@ ChartStyle.displayName = "ChartStyle"
 const ChartTooltip = RechartsPrimitive.Tooltip
 
 // Helper pour extraire les valeurs de chaîne des objets
-const extractStringValue = (obj: any, key: string): string | undefined => {
-  if (obj && typeof obj === 'object' && key in obj && typeof obj[key] === 'string') {
+const extractStringValue = (
+  obj: Record<string, unknown> | undefined,
+  key: string
+): string | undefined => {
+  if (obj && key in obj && typeof obj[key] === 'string') {
     return obj[key]
   }
   return undefined

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,7 +12,7 @@ export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
 
-export function withDisplayName<T extends React.ComponentType<any>>(
+export function withDisplayName<P = Record<string, unknown>, T extends React.ComponentType<P>>( 
   Component: T,
   displayName: string
 ): T {

--- a/src/stores/useDevToolsStore.ts
+++ b/src/stores/useDevToolsStore.ts
@@ -6,7 +6,42 @@ type MinifiedCode = {
   js: string;
 };
 
-type CodeStats = {
+interface JSHintError {
+  reason: string;
+  line: number;
+  character: number;
+}
+
+interface ComplexityResult {
+  complexity: {
+    cyclomatic: number;
+    sloc: {
+      physical: number;
+      logical: number;
+    };
+    halstead: {
+      bugs: number;
+      difficulty: number;
+      effort: number;
+      length: number;
+      time: number;
+      vocabulary: number;
+      volume: number;
+    };
+  };
+  functions: Array<{
+    name: string;
+    complexity: {
+      cyclomatic: number;
+      sloc: {
+        physical: number;
+        logical: number;
+      };
+    };
+  }>;
+}
+
+interface CodeStats {
   lines: number;
   htmlLines: number;
   cssLines: number;
@@ -19,32 +54,32 @@ type CodeStats = {
   comments: number;
   commentRatio: number;
   maintainabilityIndex: number;
-  codeSmells: any[]; // à typiser plus tard si besoin
+  codeSmells: string[];
 };
 
-type DevToolsStore = {
+interface DevToolsStore {
   advancedMode: boolean;
   htmlCode: string;
   cssCode: string;
   jsCode: string;
-  jshintResults: any[]; // à affiner selon le type des résultats JSHint
+  jshintResults: JSHintError[];
   minifiedCode: MinifiedCode;
   obfuscatedCode: string;
-  complexityResults: any; // idem, à typiser si structure connue
+  complexityResults: ComplexityResult | null;
   codeStats: CodeStats;
 
   setAdvancedMode: (enabled: boolean) => void;
   setHtmlCode: (code: string) => void;
   setCssCode: (code: string) => void;
   setJsCode: (code: string) => void;
-  setJshintResults: (results: any[]) => void;
+  setJshintResults: (results: JSHintError[]) => void;
   setMinifiedCode: (code: MinifiedCode) => void;
   setObfuscatedCode: (code: string) => void;
-  setComplexityResults: (results: any) => void;
+  setComplexityResults: (results: ComplexityResult | null) => void;
   setCodeStats: (stats: CodeStats) => void;
   generatePreviewHTML: () => string;
   resetDevTools: () => void;
-};
+}
 
 const useDevToolsStore = create<DevToolsStore>((set, get) => ({
   advancedMode: false,

--- a/src/stores/useEditorStore.ts
+++ b/src/stores/useEditorStore.ts
@@ -127,10 +127,11 @@ skills: ["JavaScript", "React", "CSS"]
           case 'typescript':
             formatted = formatJavaScript(originalCode, beautifyOptions);
             break;
-          case 'json':
+          case 'json': {
             const parsed = JSON.parse(originalCode);
             formatted = JSON.stringify(parsed, null, beautifyOptions.indent_size);
             break;
+          }
           case 'yaml':
             formatted = formatYAML(originalCode, beautifyOptions);
             break;
@@ -140,8 +141,9 @@ skills: ["JavaScript", "React", "CSS"]
           default:
             formatted = originalCode;
         }
-      } catch (error: any) {
-        formatted = `// Error formatting code:\n// ${error.message}\n\n${originalCode}`;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        formatted = `// Error formatting code:\n// ${message}\n\n${originalCode}`;
       }
 
       set({ formattedCode: formatted, isFormatted: true });
@@ -196,7 +198,7 @@ skills: ["JavaScript", "React", "CSS"]
 
 // Formatter Functions – pas encore typés finement
 function formatHTML(code: string, options: BeautifyOptions): string {
-  let formatted = code.replace(/>\s+</g, '><');
+  const formatted = code.replace(/>\s+</g, '><');
   let indentLevel = 0;
   const indent = ' '.repeat(options.indent_size);
   const lines = formatted.split(/></);
@@ -233,8 +235,8 @@ function formatCSS(code: string, options: BeautifyOptions): string {
 
 function formatJavaScript(code: string, options: BeautifyOptions): string {
   const indent = ' '.repeat(options.indent_size);
-  let formatted = code
-    .replace(/([=+\-*\/])/g, ' $1 ')
+  const formatted = code
+    .replace(/([=+*/-])/g, ' $1 ')
     .replace(/\s+/g, ' ')
     .replace(/\{/g, options.brace_style === 'expand' ? '\n{\n' : ' {\n')
     .replace(/\}/g, '\n}\n')

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -94,5 +95,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- resolve eslint complaints in DevTools components and stores
- replace `any` usages with typed interfaces and aliases
- remove unused imports and improve global typings
- switch tailwind plugin to ESM import

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e6face60c8322928701be41ab633a